### PR TITLE
Disable list looping

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,7 @@ git.branchLocal(async (_commands, output) => {
         b === output.current ? `${b} ${chalk.italic('(current)')}` : b
       ),
       default: output.all.indexOf(output.current),
+      loop: false,
     },
   ])
 


### PR DESCRIPTION
Tyckte det blev lite snurrigt att inte se tydligt var listan slutade och började i ett repo med många branches. En annan variant skulle ju kunna vara att numrera alternativen. Eller någon tydlig brytpunkt som en tom rad, eller `===========`. 